### PR TITLE
Fix keyword argument separation warnings on Ruby 2.7

### DIFF
--- a/lib/grpc_kit/calls/client_bidi_streamer.rb
+++ b/lib/grpc_kit/calls/client_bidi_streamer.rb
@@ -10,7 +10,7 @@ module GrpcKit
 
       alias outgoing_metadata metadata
 
-      def initialize(*)
+      def initialize(**)
         super
         @mutex = Mutex.new
         @send = false

--- a/lib/grpc_kit/calls/server_bidi_streamer.rb
+++ b/lib/grpc_kit/calls/server_bidi_streamer.rb
@@ -11,7 +11,7 @@ module GrpcKit
       attr_reader :outgoing_initial_metadata, :outgoing_trailing_metadata
       alias incoming_metadata metadata
 
-      def initialize(*)
+      def initialize(**)
         super
 
         @outgoing_initial_metadata = {}

--- a/lib/grpc_kit/calls/server_client_streamer.rb
+++ b/lib/grpc_kit/calls/server_client_streamer.rb
@@ -11,7 +11,7 @@ module GrpcKit
       attr_reader :outgoing_initial_metadata, :outgoing_trailing_metadata
       alias incoming_metadata metadata
 
-      def initialize(*)
+      def initialize(**)
         super
 
         @outgoing_initial_metadata = {}

--- a/lib/grpc_kit/calls/server_request_response.rb
+++ b/lib/grpc_kit/calls/server_request_response.rb
@@ -9,7 +9,7 @@ module GrpcKit
       attr_reader :outgoing_initial_metadata, :outgoing_trailing_metadata
       alias incoming_metadata metadata
 
-      def initialize(*)
+      def initialize(**)
         super
 
         @outgoing_initial_metadata = {}

--- a/lib/grpc_kit/calls/server_server_streamer.rb
+++ b/lib/grpc_kit/calls/server_server_streamer.rb
@@ -9,7 +9,7 @@ module GrpcKit
       attr_reader :outgoing_initial_metadata, :outgoing_trailing_metadata
       alias incoming_metadata metadata
 
-      def initialize(*)
+      def initialize(**)
         super
 
         @outgoing_initial_metadata = {}

--- a/lib/grpc_kit/client.rb
+++ b/lib/grpc_kit/client.rb
@@ -32,14 +32,14 @@ module GrpcKit
     # @param opts [Hash]
     def request_response(rpc, request, opts = {})
       GrpcKit.logger.debug('Calling request_respose')
-      do_request(rpc, request, opts)
+      do_request(rpc, request, **opts)
     end
 
     # @param rpc [GrpcKit::Rpcs::Client::ClientStreamer]
     # @param opts [Hash]
     def client_streamer(rpc, opts = {})
       GrpcKit.logger.debug('Calling client_streamer')
-      do_request(rpc, nil, opts)
+      do_request(rpc, nil, **opts)
     end
 
     # @param rpc [GrpcKit::Rpcs::Client::ServerStreamer]
@@ -47,7 +47,7 @@ module GrpcKit
     # @param opts [Hash]
     def server_streamer(rpc, request, opts = {})
       GrpcKit.logger.debug('Calling server_streamer')
-      do_request(rpc, request, opts)
+      do_request(rpc, request, **opts)
     end
 
     # @param rpc [GrpcKit::Rpcs::Client::ServerStreamer]
@@ -55,7 +55,7 @@ module GrpcKit
     # @param opts [Hash]
     def bidi_streamer(rpc, _requests, opts = {})
       GrpcKit.logger.debug('Calling bidi_streamer')
-      do_request(rpc, nil, opts)
+      do_request(rpc, nil, **opts)
     end
 
     private

--- a/lib/grpc_kit/client.rb
+++ b/lib/grpc_kit/client.rb
@@ -30,14 +30,14 @@ module GrpcKit
     # @param rpc [GrpcKit::Rpcs::Client::RequestResponse]
     # @param request [Object]
     # @param opts [Hash]
-    def request_response(rpc, request, opts = {})
+    def request_response(rpc, request, **opts)
       GrpcKit.logger.debug('Calling request_respose')
       do_request(rpc, request, **opts)
     end
 
     # @param rpc [GrpcKit::Rpcs::Client::ClientStreamer]
     # @param opts [Hash]
-    def client_streamer(rpc, opts = {})
+    def client_streamer(rpc, **opts)
       GrpcKit.logger.debug('Calling client_streamer')
       do_request(rpc, nil, **opts)
     end
@@ -45,7 +45,7 @@ module GrpcKit
     # @param rpc [GrpcKit::Rpcs::Client::ServerStreamer]
     # @param request [Object]
     # @param opts [Hash]
-    def server_streamer(rpc, request, opts = {})
+    def server_streamer(rpc, request, **opts)
       GrpcKit.logger.debug('Calling server_streamer')
       do_request(rpc, request, **opts)
     end
@@ -53,7 +53,7 @@ module GrpcKit
     # @param rpc [GrpcKit::Rpcs::Client::ServerStreamer]
     # @param _requests [Object] it's for compatibility, no use
     # @param opts [Hash]
-    def bidi_streamer(rpc, _requests, opts = {})
+    def bidi_streamer(rpc, _requests, **opts)
       GrpcKit.logger.debug('Calling bidi_streamer')
       do_request(rpc, nil, **opts)
     end

--- a/lib/grpc_kit/grpc/dsl.rb
+++ b/lib/grpc_kit/grpc/dsl.rb
@@ -82,20 +82,20 @@ module GrpcKit
 
           rpc_descs_.each do |method_name, rpc_desc|
             if rpc_desc.request_response?
-              define_method(method_name) do |request, opts = {}|
-                request_response(@rpcs.fetch(method_name), request, opts)
+              define_method(method_name) do |request, **opts|
+                request_response(@rpcs.fetch(method_name), request, **opts)
               end
             elsif rpc_desc.client_streamer?
-              define_method(method_name) do |opts = {}|
-                client_streamer(@rpcs.fetch(method_name), opts)
+              define_method(method_name) do |**opts|
+                client_streamer(@rpcs.fetch(method_name), **opts)
               end
             elsif rpc_desc.server_streamer?
-              define_method(method_name) do |request, opts = {}|
-                server_streamer(@rpcs.fetch(method_name), request, opts)
+              define_method(method_name) do |request, **opts|
+                server_streamer(@rpcs.fetch(method_name), request, **opts)
               end
             elsif rpc_desc.bidi_streamer?
-              define_method(method_name) do |requests, opts = {}, &blk|
-                bidi_streamer(@rpcs.fetch(method_name), requests, opts, &blk)
+              define_method(method_name) do |requests, **opts, &blk|
+                bidi_streamer(@rpcs.fetch(method_name), requests, **opts, &blk)
               end
             else
               raise "unknown #{rpc_desc}"

--- a/lib/grpc_kit/grpc/dsl.rb
+++ b/lib/grpc_kit/grpc/dsl.rb
@@ -68,7 +68,7 @@ module GrpcKit
         end
 
         Class.new(GrpcKit::Client) do
-          def initialize(*)
+          def initialize(*, **)
             @rpcs = {}
             super
           end

--- a/lib/grpc_kit/session/client_session.rb
+++ b/lib/grpc_kit/session/client_session.rb
@@ -18,7 +18,7 @@ module GrpcKit
 
       # @param io [GrpcKit::Session::IO]
       # @param opts [Hash]
-      def initialize(io, opts = {})
+      def initialize(io, **opts)
         super() # initialize DS9::Session
 
         @io = io


### PR DESCRIPTION
Using grpc_kit with Ruby 2.7 will emit warnings along the lines of:

```
/path/to/grpc_kit/lib/grpc_kit/calls/server_bidi_streamer.rb:15: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/grpc_kit/lib/grpc_kit/call.rb:24: warning: The called method `initialize' is defined here
```

The details of the warning are explained in https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/.

This also enables tests to run on Ruby 2.7 on Travis  CI.