### PR TITLE
ServerStream: Submit trailer in prior to end_write

### DIFF
--- a/lib/grpc_kit/stream/server_stream.rb
+++ b/lib/grpc_kit/stream/server_stream.rb
@@ -89,13 +89,16 @@ module GrpcKit
         t = build_trailers(status, msg, metadata)
         @transport.write_data(data, last: true) if data
 
-        @transport.end_write
         if @started
           @transport.write_trailers(t)
+          @transport.end_write
         elsif data
           @transport.write_trailers(t)
+          @transport.end_write
+
           start_response
         else
+          @transport.end_write
           send_headers(trailers: t)
         end
       end

--- a/lib/grpc_kit/stream/server_stream.rb
+++ b/lib/grpc_kit/stream/server_stream.rb
@@ -89,15 +89,17 @@ module GrpcKit
         t = build_trailers(status, msg, metadata)
         @transport.write_data(data, last: true) if data
 
-        if @started
-          @transport.write_trailers(t)
-          @transport.end_write
-        elsif data
+        if @started # Complete stream
           @transport.write_trailers(t)
           @transport.end_write
 
-          start_response
-        else
+        elsif data # Complete stream with a data
+          @transport.write_trailers(t)
+          @transport.end_write
+
+          start_response # will send queued data and trailer.
+
+        else # return status (likely non-200) and immediately complete stream.
           @transport.end_write
           send_headers(trailers: t)
         end


### PR DESCRIPTION
Trailers must be submitted before end_write.

ServerSession#on_data_source_read attempts to send a trailer
once SendBuffer got closed. This attempt only happens once so trailers
must be submitted before calling end_write which closes a SendBuffer.

Otherwise empty trailer HEADERS frame would be sent to a client.