### PR TITLE
Configurable max_message_size

### DIFF
--- a/lib/grpc_kit/client.rb
+++ b/lib/grpc_kit/client.rb
@@ -12,9 +12,9 @@ module GrpcKit
     # @param authority [nil, String]
     # @param interceptors [Array<GrpcKit::Grpc::ClientInterceptor>] list of interceptors
     # @param timeout [nil, Integer, String]
-    # @param default_max_receive_message_size [Integer, nil] Specify the default maximum size of inbound message in bytes. Default to 4MB. A value specified on RpcDesc take precedence over this configuration.
-    # @param default_max_send_message_size [Integer, nil] Specify the default maximum size of outbound message in bytes. Default to 4MB. A value specified on RpcDesc take precedence over this configuration.
-    def initialize(sock, authority: nil, interceptors: [], timeout: nil, default_max_receive_message_size: nil, default_max_send_message_size: nil)
+    # @param max_receive_message_size [Integer, nil] Specify the default maximum size of inbound message in bytes. Default to 4MB.
+    # @param max_send_message_size [Integer, nil] Specify the default maximum size of outbound message in bytes. Default to 4MB.
+    def initialize(sock, authority: nil, interceptors: [], timeout: nil, max_receive_message_size: nil, max_send_message_size: nil)
       @sock = sock
       @authority =
         if authority
@@ -29,8 +29,8 @@ module GrpcKit
       # Defined at GrpcKit::Grpc::Dsl#.rpc_stub_class
       build_rpcs(
         interceptors,
-        max_receive_message_size: default_max_receive_message_size,
-        max_send_message_size: default_max_send_message_size,
+        max_receive_message_size: max_receive_message_size,
+        max_send_message_size: max_send_message_size,
       )
     end
 

--- a/lib/grpc_kit/client.rb
+++ b/lib/grpc_kit/client.rb
@@ -12,7 +12,9 @@ module GrpcKit
     # @param authority [nil, String]
     # @param interceptors [Array<GrpcKit::Grpc::ClientInterceptor>] list of interceptors
     # @param timeout [nil, Integer, String]
-    def initialize(sock, authority: nil, interceptors: [], timeout: nil)
+    # @param default_max_receive_message_size [Integer, nil] Specify the default maximum size of inbound message in bytes. Default to 4MB. A value specified on RpcDesc take precedence over this configuration.
+    # @param default_max_send_message_size [Integer, nil] Specify the default maximum size of outbound message in bytes. Default to 4MB. A value specified on RpcDesc take precedence over this configuration.
+    def initialize(sock, authority: nil, interceptors: [], timeout: nil, default_max_receive_message_size: nil, default_max_send_message_size: nil)
       @sock = sock
       @authority =
         if authority
@@ -24,7 +26,12 @@ module GrpcKit
 
       @timeout = timeout && GrpcKit::GrpcTime.new(timeout)
 
-      build_rpcs(interceptors)
+      # Defined at GrpcKit::Grpc::Dsl#.rpc_stub_class
+      build_rpcs(
+        interceptors,
+        max_receive_message_size: default_max_receive_message_size,
+        max_send_message_size: default_max_send_message_size,
+      )
     end
 
     # @param rpc [GrpcKit::Rpcs::Client::RequestResponse]

--- a/lib/grpc_kit/grpc/dsl.rb
+++ b/lib/grpc_kit/grpc/dsl.rb
@@ -7,6 +7,8 @@ require 'grpc_kit/grpc/stream'
 
 module GrpcKit
   module Grpc
+    # Methods under GrpcKit::Grpc::Dsl is available for classes include GRPC::GenericService.
+    # See also: GrpcKit::Grpc::GenericService
     module Dsl
       # @param value [String]
       attr_accessor :service_name
@@ -73,9 +75,9 @@ module GrpcKit
             super
           end
 
-          define_method(:build_rpcs) do |interceptors|
+          define_method(:build_rpcs) do |interceptors, **options|
             rpc_descs_.each do |method_name, rpc_desc|
-              @rpcs[method_name] = rpc_desc.build_client(interceptors: interceptors)
+              @rpcs[method_name] = rpc_desc.build_client(interceptors: interceptors, **options)
             end
           end
           private :build_rpcs
@@ -107,6 +109,15 @@ module GrpcKit
       # @return [Hash<String,GrpcKit::RpcDesc>]
       def rpc_descs
         @rpc_descs ||= {}
+      end
+
+      # @param method_name [Symbol] Ruby method name to find a RpcDesc
+      # @yield [GrpcKit::RpcDesc] Corresponding RpcDesc object for the specified method_name
+      def configure_rpc(method_name)
+        rpc_desc = rpc_descs.each_value.find { |rd| rd.ruby_style_name == method_name }
+        raise "No RPC found for the method: #{method_name.inspect}" unless rpc_desc
+
+        yield rpc_desc
       end
     end
   end

--- a/lib/grpc_kit/grpc/dsl.rb
+++ b/lib/grpc_kit/grpc/dsl.rb
@@ -110,15 +110,6 @@ module GrpcKit
       def rpc_descs
         @rpc_descs ||= {}
       end
-
-      # @param method_name [Symbol] Ruby method name to find a RpcDesc
-      # @yield [GrpcKit::RpcDesc] Corresponding RpcDesc object for the specified method_name
-      def configure_rpc(method_name)
-        rpc_desc = rpc_descs.each_value.find { |rd| rd.ruby_style_name == method_name }
-        raise "No RPC found for the method: #{method_name.inspect}" unless rpc_desc
-
-        yield rpc_desc
-      end
     end
   end
 end

--- a/lib/grpc_kit/method_config.rb
+++ b/lib/grpc_kit/method_config.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 module GrpcKit
+  MAX_SERVER_RECEIVE_MESSAGE_SIZE = 1024 * 1024 * 4
+  MAX_SERVER_SEND_MESSAGE_SIZE = 1024 * 1024 * 4
+  MAX_CLIENT_RECEIVE_MESSAGE_SIZE = 1024 * 1024 * 4
+  MAX_CLIENT_SEND_MESSAGE_SIZE = 1024 * 1024 * 4
+
   MethodConfig = Struct.new(
     :path,
     :ruby_style_method_name,
@@ -12,11 +17,6 @@ module GrpcKit
     :max_send_message_size,
     :compressor_type,
   ) do
-    MAX_SERVER_RECEIVE_MESSAGE_SIZE = 1024 * 1024 * 4
-    MAX_SERVER_SEND_MESSAGE_SIZE = 1024 * 1024 * 4
-    MAX_CLIENT_RECEIVE_MESSAGE_SIZE = 1024 * 1024 * 4
-    MAX_CLIENT_SEND_MESSAGE_SIZE = 1024 * 1024 * 4
-
     def self.build_for_server(
           path:, ruby_style_method_name:, codec:, service_name:, method_name:, interceptor:,
           max_receive_message_size: MAX_SERVER_RECEIVE_MESSAGE_SIZE, max_send_message_size: MAX_SERVER_SEND_MESSAGE_SIZE, compressor_type: ''

--- a/lib/grpc_kit/rpc_desc.rb
+++ b/lib/grpc_kit/rpc_desc.rb
@@ -38,6 +38,15 @@ module GrpcKit
       @service_name = service_name
     end
 
+    # @return [String]
+    attr_reader :name, :service_name
+
+    # @return [Class, GrpcKit::Grpc::Stream]
+    attr_reader :marshal, :unmarshal
+
+    # @return [Symbol]
+    attr_reader :marshal_method, :unmarshal_method
+
     # @param handler [GrpcKit::Grpc::GenericService]
     # @param interceptors [Array<GrpcKit::Grpc::ServerInterceptor>]
     # @return [#invoke] Server version of rpc class

--- a/lib/grpc_kit/rpc_desc.rb
+++ b/lib/grpc_kit/rpc_desc.rb
@@ -29,17 +29,13 @@ module GrpcKit
     # @param marshal_method [Symbol] method name of marshaling which marshal is called this method
     # @param unmarshal_method [Symbol] method name of unmarshaling which unmarshal is called this method
     # @param service_name [String]
-    # @param max_server_message_size [Integer, nil] Specify maximum size of server outbound message in bytes. Default to 4MB. Takes precedence over the value specified to GrpcKit::Server and GrpcKit::Client instance.
-    # @param max_client_message_size [Integer, nil] Specify maximum size of client outbound message in bytes. Default to 4MB. Takes precedence over the value specified to GrpcKit::Server and GrpcKit::Client instance.
-    def initialize(name:, marshal:, unmarshal:, marshal_method:, unmarshal_method:, service_name:, max_receive_message_size: nil, max_send_message_size: nil)
+    def initialize(name:, marshal:, unmarshal:, marshal_method:, unmarshal_method:, service_name:)
       @name = name
       @marshal = marshal
       @unmarshal = unmarshal
       @marshal_method = marshal_method
       @unmarshal_method = unmarshal_method
       @service_name = service_name
-      @max_server_message_size = max_receive_message_size
-      @max_client_message_size = max_send_message_size
     end
 
     # @return [String]
@@ -50,9 +46,6 @@ module GrpcKit
 
     # @return [Symbol]
     attr_reader :marshal_method, :unmarshal_method
-
-    # @return [Integer, nil]
-    attr_accessor :max_server_message_size, :max_client_message_size
 
     # @param handler [GrpcKit::Grpc::GenericService]
     # @param interceptors [Array<GrpcKit::Grpc::ServerInterceptor>]
@@ -69,8 +62,8 @@ module GrpcKit
         service_name: @service_name,
         method_name: @name,
         interceptor: inter,
-        max_receive_message_size: @max_client_message_size || max_receive_message_size || GrpcKit::MAX_SERVER_RECEIVE_MESSAGE_SIZE,
-        max_send_message_size: @max_server_message_size || max_send_message_size || GrpcKit::MAX_SERVER_SEND_MESSAGE_SIZE,
+        max_receive_message_size: max_receive_message_size || GrpcKit::MAX_SERVER_RECEIVE_MESSAGE_SIZE,
+        max_send_message_size: max_send_message_size || GrpcKit::MAX_SERVER_SEND_MESSAGE_SIZE,
       )
       server.new(handler, config)
     end
@@ -89,8 +82,8 @@ module GrpcKit
         service_name: @service_name,
         method_name: @name,
         interceptor: inter,
-        max_receive_message_size: @max_server_message_size || max_receive_message_size || GrpcKit::MAX_CLIENT_RECEIVE_MESSAGE_SIZE,
-        max_send_message_size: @max_client_message_size || max_send_message_size || GrpcKit::MAX_CLIENT_SEND_MESSAGE_SIZE,
+        max_receive_message_size: max_receive_message_size || GrpcKit::MAX_CLIENT_RECEIVE_MESSAGE_SIZE,
+        max_send_message_size: max_send_message_size || GrpcKit::MAX_CLIENT_SEND_MESSAGE_SIZE,
       )
       client.new(config)
     end

--- a/lib/grpc_kit/rpcs.rb
+++ b/lib/grpc_kit/rpcs.rb
@@ -19,6 +19,9 @@ module GrpcKit
     end
 
     class ServerRpc
+      # @return [GrpcKit::MethodConfig]
+      attr_reader :config
+
       # @param handler [GrpcKit::Grpc::GenericService]
       # @param config [GrpcKit::MethodConfig]
       def initialize(handler, config)

--- a/lib/grpc_kit/server.rb
+++ b/lib/grpc_kit/server.rb
@@ -10,15 +10,15 @@ module GrpcKit
     # @param shutdown_timeout [Integer] Number of seconds to wait for the server shutdown
     # @param min_pool_size [Integer] A mininum thread pool size
     # @param max_pool_size [Integer] A maximum thread pool size
-    # @param default_max_receive_message_size [Integer, nil] Specify the default maximum size of inbound message in bytes. Default to 4MB. A value specified on RpcDesc take precedence over this configuration.
-    # @param default_max_send_message_size [Integer, nil] Specify the default maximum size of outbound message in bytes. Default to 4MB. A value specified on RpcDesc take precedence over this configuration.
-    def initialize(interceptors: [], shutdown_timeout: 30, min_pool_size: nil, max_pool_size: nil, settings: [], default_max_receive_message_size: nil, default_max_send_message_size: nil)
+    # @param max_receive_message_size [Integer, nil] Specify the maximum size of inbound message in bytes. Default to 4MB.
+    # @param max_send_message_size [Integer, nil] Specify the maximum size of outbound message in bytes. Default to 4MB.
+    def initialize(interceptors: [], shutdown_timeout: 30, min_pool_size: nil, max_pool_size: nil, settings: [], max_receive_message_size: nil, max_send_message_size: nil)
       @interceptors = interceptors
       @shutdown_timeout = shutdown_timeout
       @min_pool_size = min_pool_size || GrpcKit::RpcDispatcher::DEFAULT_MIN
       @max_pool_size = max_pool_size || GrpcKit::RpcDispatcher::DEFAULT_MAX
-      @default_max_receive_message_size = default_max_receive_message_size
-      @default_max_send_message_size = default_max_send_message_size
+      @max_receive_message_size = max_receive_message_size
+      @max_send_message_size = max_send_message_size
       @sessions = []
       @rpc_descs = {}
       @mutex = Mutex.new
@@ -44,8 +44,8 @@ module GrpcKit
         @rpc_descs[path] = rpc_desc.build_server(
           handler.is_a?(Class) ? handler.new : handler,
           interceptors: @interceptors,
-          max_receive_message_size: @default_max_receive_message_size,
-          max_send_message_size: @default_max_send_message_size,
+          max_receive_message_size: @max_receive_message_size,
+          max_send_message_size: @max_send_message_size,
         )
       end
     end


### PR DESCRIPTION
Allow configuring max message size in 2 ways. We may now specify a maximum size in GRPC::GenericService (GrpcKit::Grpc::GenericService), GrpcKit::Server and GrpcKit::Client.

The values specified in GRPC::GenericService takes precedence over GrpcKit::Server and GrpcKit::Client.

``` ruby
client = Helloworld::Greeter::Service::Stub.new(
  ...,
  max_receive_message_size: 1024 * 1024 * 2,
  max_send_message_size: 1024 * 1024 * 1,
)

server = GrpcKit::Server.new(
  max_receive_message_size: 1024 * 1024 * 1,
  max_send_message_size: 1024 * 1024 * 2,
)
```

@cookpad/infra r