### PR TITLE
Set END_STREAM flag on the last DATA frame on request stream

### DIFF
--- a/lib/grpc_kit/session/send_buffer.rb
+++ b/lib/grpc_kit/session/send_buffer.rb
@@ -65,6 +65,10 @@ module GrpcKit
         DS9::ERR_DEFERRED
       end
 
+      def eof?
+        end_write? && @mutex.synchronize { @buffer.empty? }
+      end
+
       private
 
       def do_read(size = nil)


### PR DESCRIPTION
Combined with https://github.com/tenderlove/ds9/pull/20, this PR sets the END_STREAM flag on the last DATA frame on a request stream, instead of adding an empty DATA frame with the END_STREAM flag set as a last DATA frame.

We are seeing a compatibility issue with AWS ALB when a server sends a complete response back without waiting for the last empty DATA frame with the END_STREAM flag set and sends a RST_STREAM frame with an error code of NO_ERROR as described in https://tools.ietf.org/html/rfc7540#section-8.1. I'm hopeing this change will mitigate the issue.

Note that no new release has been published to rubygems.org since https://github.com/tenderlove/ds9/pull/20 has been merged, so you'll have to install the ds9 gem from the git repository to take advantage of this change for the time being.