### PR TITLE
Add TruffleRuby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ jobs:
           - 2.7
           - 3.0
           - 3.1
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '${{ matrix.ruby_version }}'
+          bundler-cache: true
+
+      - run: 'bundle exec rake'
+
+  truffleruby:
+    name: truffleruby
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby_version:
           - truffleruby-head
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - 2.7
           - 3.0
           - 3.1
+          - truffleruby-head
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version:
-          - 2.5
-          - 2.6
-          - 2.7
-          - 3.0
-          - 3.1
+        ruby_version: ['2.5', '2.6', '2.7', '3.0', '3.1']
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
@@ -31,8 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version:
-          - truffleruby-head
+        ruby_version: [truffleruby-head]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
On top of https://github.com/cookpad/grpc_kit/pull/36 to get those fixes.
Still needs a small fix in TruffleRuby to add `exception:` keyword to StringIO first, cc @andrykonchin (https://github.com/oracle/truffleruby/issues/2247#issuecomment-1222620177).