### PR TITLE
Fix exceptions in an auto-trimmer thread in CI build with TruffleRuby

### DIFF
--- a/lib/grpc_kit/rpc_dispatcher.rb
+++ b/lib/grpc_kit/rpc_dispatcher.rb
@@ -17,9 +17,6 @@ module GrpcKit
       @rpcs = rpcs
       @max_pool_size = max
       @min_pool_size = min
-      unless max == min
-        @auto_trimmer = AutoTrimmer.new(self, interval: interval).tap(&:start!)
-      end
 
       @shutdown = false
       @tasks = Queue.new
@@ -28,6 +25,10 @@ module GrpcKit
       @mutex = Mutex.new
 
       @min_pool_size.times { spawn_thread }
+
+      unless max == min
+        @auto_trimmer = AutoTrimmer.new(self, interval: interval).tap(&:start!)
+      end
     end
 
     # @param task [Object] task to dispatch


### PR DESCRIPTION
Fix `NoMethodError` exceptions I noticed on CI when specs are run against TruffleRuby.

Example ([CI build](https://github.com/cookpad/grpc_kit/actions/runs/2919230473/jobs/4653135963))

```
#<Thread:0x36d38 /home/runner/work/grpc_kit/grpc_kit/lib/grpc_kit/rpc_dispatcher/auto_trimmer.rb:14 run> terminated with exception (report_on_exception is true):
/home/runner/work/grpc_kit/grpc_kit/lib/grpc_kit/rpc_dispatcher.rb:56:in `trim': undefined method `empty?' for nil:NilClass (NoMethodError)
	from /home/runner/work/grpc_kit/grpc_kit/lib/grpc_kit/rpc_dispatcher/auto_trimmer.rb:20:in `block (2 levels) in start!'
	from <internal:core> core/kernel.rb:407:in `loop'
	from /home/runner/work/grpc_kit/grpc_kit/lib/grpc_kit/rpc_dispatcher/auto_trimmer.rb:15:in `block in start!'
```

Not sure whether the order of initialising instance variables and starting the auto-trimmer thread might cause issues in production (in case TruffleRuby is used) but at least there will be less noise on CI.